### PR TITLE
feat: amélioration UI/UX des paramètres et persistance des préférences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ env
 frontend/src/assets/documents
 
 
+go.mod

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ frontend/src/assets/documents
 go.mod
 code.MD
 .DS_Store
+SUIVI-GIT.md

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ frontend/src/assets/documents
 
 
 go.mod
+code.MD
+.DS_Store

--- a/app.go
+++ b/app.go
@@ -91,21 +91,6 @@ func (a *App) startup(ctx context.Context) {
 // domReady is called after front-end resources have been loaded
 func (a *App) domReady(ctx context.Context) {
 	a.ctx = ctx
-	parametres, err := params.ChargerParametres(".")
-	if err != nil {
-		a.signalerErreur(err)
-		return
-	}
-	script := fmt.Sprintf(`
-window.contrastes = %t;
-window.dyslexie = %t;
-window.non_aux_bubulles = %t;
-const iframe = document.getElementsByTagName("iframe")[0];
-if (iframe && iframe.getAttribute("src")) {
-    iframe.setAttribute("src", iframe.getAttribute("src"));
-}
-`, parametres.Contrastes, parametres.Dyslexie, parametres.NonAuxBubulles)
-	runtime.WindowExecJS(ctx, script)
 }
 
 // beforeClose is called when the application is about to quit,
@@ -159,13 +144,40 @@ func (a *App) alerterEnregistrementErreurImpossible() {
 	runtime.WindowExecJS(a.ctx, "details_erreur()")
 }
 
+func (a *App) getCheminBaseApplication() (string, error) {
+	emplacementExecutable, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(emplacementExecutable), nil
+}
+
 func (a *App) SauvegarderParametres(contrastes bool, dyslexie bool, nonAuxBubulles bool) bool {
-	err := params.SauvegarderParametres(".", contrastes, dyslexie, nonAuxBubulles)
+	cheminBase, err := a.getCheminBaseApplication()
+	if err != nil {
+		a.signalerErreur(err)
+		return false
+	}
+	err = params.SauvegarderParametres(cheminBase, contrastes, dyslexie, nonAuxBubulles)
 	if err != nil {
 		a.signalerErreur(err)
 		return false
 	}
 	return true
+}
+
+func (a *App) GetParametres() params.ParametresXML {
+	cheminBase, err := a.getCheminBaseApplication()
+	if err != nil {
+		a.signalerErreur(err)
+		return params.ParametresXML{}
+	}
+	parametres, err := params.ChargerParametres(cheminBase)
+	if err != nil {
+		a.signalerErreur(err)
+		return params.ParametresXML{}
+	}
+	return parametres
 }
 
 /***************************************************************************************/

--- a/app.go
+++ b/app.go
@@ -47,6 +47,7 @@ import (
 	"aquarium/modules/detection"
 	"aquarium/modules/extraction"
 	"aquarium/modules/gestionprojet"
+	"aquarium/modules/params"
 	"aquarium/modules/rapport"
 	"context"
 	"fmt"
@@ -88,8 +89,23 @@ func (a *App) startup(ctx context.Context) {
 }
 
 // domReady is called after front-end resources have been loaded
-func (a App) domReady(ctx context.Context) {
-	// Add your action here
+func (a *App) domReady(ctx context.Context) {
+	a.ctx = ctx
+	parametres, err := params.ChargerParametres(".")
+	if err != nil {
+		a.signalerErreur(err)
+		return
+	}
+	script := fmt.Sprintf(`
+window.contrastes = %t;
+window.dyslexie = %t;
+window.non_aux_bubulles = %t;
+const iframe = document.getElementsByTagName("iframe")[0];
+if (iframe && iframe.getAttribute("src")) {
+    iframe.setAttribute("src", iframe.getAttribute("src"));
+}
+`, parametres.Contrastes, parametres.Dyslexie, parametres.NonAuxBubulles)
+	runtime.WindowExecJS(ctx, script)
 }
 
 // beforeClose is called when the application is about to quit,
@@ -141,6 +157,15 @@ func (a *App) signalerErreur(erreur error) {
 
 func (a *App) alerterEnregistrementErreurImpossible() {
 	runtime.WindowExecJS(a.ctx, "details_erreur()")
+}
+
+func (a *App) SauvegarderParametres(contrastes bool, dyslexie bool, nonAuxBubulles bool) bool {
+	err := params.SauvegarderParametres(".", contrastes, dyslexie, nonAuxBubulles)
+	if err != nil {
+		a.signalerErreur(err)
+		return false
+	}
+	return true
 }
 
 /***************************************************************************************/

--- a/app.go
+++ b/app.go
@@ -54,6 +54,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -121,7 +122,7 @@ func (a *App) signalerErreur(erreur error) {
 		cheminErreurs = filepath.Join(filepath.Dir(cheminExecutable), DOSSIER_ERREURS)
 	}
 	// Créer le dossier des erreur s’il n’existe pas
-	err := os.MkdirAll(cheminErreurs, os.ModeAppend)
+	err := os.MkdirAll(cheminErreurs, 0o755)
 	if err != nil {
 		a.alerterEnregistrementErreurImpossible()
 		return
@@ -152,10 +153,13 @@ func (a *App) alerterEnregistrementErreurImpossible() {
 @return : vrai si et seulement si l'analyse a été correctement ouverte
 */
 func (a *App) OuvrirAnalyseExistante() bool {
-	fichier, err := runtime.OpenFileDialog(a.ctx, runtime.OpenDialogOptions{
-		Title:   "Ouvrir une analyse existante",
-		Filters: []runtime.FileFilter{{DisplayName: "Aquarium", Pattern: "analyse.aqua"}},
-	})
+	options := runtime.OpenDialogOptions{
+		Title: "Ouvrir une analyse existante",
+	}
+	if goruntime.GOOS != "darwin" {
+		options.Filters = []runtime.FileFilter{{DisplayName: "Aquarium", Pattern: "*.aqua"}}
+	}
+	fichier, err := runtime.OpenFileDialog(a.ctx, options)
 	if err != nil {
 		runtime.MessageDialog(a.ctx, runtime.MessageDialogOptions{
 			Type:    runtime.InfoDialog,
@@ -165,6 +169,14 @@ func (a *App) OuvrirAnalyseExistante() bool {
 		return false
 	}
 	if fichier == "" {
+		return false
+	}
+	if !strings.EqualFold(filepath.Base(fichier), "analyse.aqua") {
+		runtime.MessageDialog(a.ctx, runtime.MessageDialogOptions{
+			Type:    runtime.InfoDialog,
+			Title:   "Fichier invalide",
+			Message: "Veuillez sélectionner un fichier nommé analyse.aqua",
+		})
 		return false
 	}
 	chemin_projet = filepath.Dir(fichier)
@@ -463,7 +475,11 @@ func (a *App) StatutReglesDetection() []map[string]interface{} {
 /***************************************************************************************/
 
 func (a *App) ResultatRequeteSQLExtraction(requete string, debut int, taille int) []map[string]interface{} {
-	requete = fmt.Sprintf("%s LIMIT %d OFFSET %d", requete, taille, debut)
+	requete = strings.TrimSpace(requete)
+	for strings.HasSuffix(requete, ";") {
+		requete = strings.TrimSpace(strings.TrimSuffix(requete, ";"))
+	}
+	requete = fmt.Sprintf("SELECT * FROM (%s) AS requete_utilisateur LIMIT %d OFFSET %d", requete, taille, debut)
 	log.Println("[INFO] - Execution depuis JS de la requete ", requete)
 	var base aquabase.Aquabase = *aquabase.InitDB_Extraction(chemin_projet)
 	resultat, err := base.ResultatRequeteSQL(requete)

--- a/app.go
+++ b/app.go
@@ -49,6 +49,7 @@ import (
 	"aquarium/modules/gestionprojet"
 	"aquarium/modules/params"
 	"aquarium/modules/rapport"
+	"aquarium/modules/utilitaires"
 	"context"
 	"fmt"
 	"log"
@@ -144,16 +145,8 @@ func (a *App) alerterEnregistrementErreurImpossible() {
 	runtime.WindowExecJS(a.ctx, "details_erreur()")
 }
 
-func (a *App) getCheminBaseApplication() (string, error) {
-	emplacementExecutable, err := os.Executable()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Dir(emplacementExecutable), nil
-}
-
 func (a *App) SauvegarderParametres(contrastes bool, dyslexie bool, nonAuxBubulles bool) bool {
-	cheminBase, err := a.getCheminBaseApplication()
+	cheminBase, err := utilitaires.GetCheminBaseApplication()
 	if err != nil {
 		a.signalerErreur(err)
 		return false
@@ -167,7 +160,7 @@ func (a *App) SauvegarderParametres(contrastes bool, dyslexie bool, nonAuxBubull
 }
 
 func (a *App) GetParametres() params.ParametresXML {
-	cheminBase, err := a.getCheminBaseApplication()
+	cheminBase, err := utilitaires.GetCheminBaseApplication()
 	if err != nil {
 		a.signalerErreur(err)
 		return params.ParametresXML{}

--- a/config/params.xml
+++ b/config/params.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parametres>
+  <contrastes>false</contrastes>
+  <dyslexie>false</dyslexie>
+  <non_aux_bubulles>true</non_aux_bubulles>
+</parametres>

--- a/frontend/src/assets/images/croix-fermer-blanche.svg
+++ b/frontend/src/assets/images/croix-fermer-blanche.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Fermer">
+  <path d="M6 6L18 18M18 6L6 18" stroke="#FFFFFF" stroke-width="2.6" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/images/croix-fermer-noire.svg
+++ b/frontend/src/assets/images/croix-fermer-noire.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Fermer">
+  <path d="M6 6L18 18M18 6L6 18" stroke="#000000" stroke-width="2.6" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/images/croix-fermer.svg
+++ b/frontend/src/assets/images/croix-fermer.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Fermer">
+  <path d="M6 6L18 18M18 6L6 18" stroke="#FFFFFF" stroke-width="2.6" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/css/nouvelle_analyse.css
+++ b/frontend/src/css/nouvelle_analyse.css
@@ -55,6 +55,29 @@ termes.
     overflow: hidden;
 }
 
+#formulaire{
+    position: relative;
+}
+
+.bouton_fermeture_nouvelle_analyse{
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 40px;
+    height: 40px;
+    border: none;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+    z-index: 2;
+}
+
+.icone_fermeture_nouvelle_analyse{
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
 /* Configuration de la navigation */
 
 .navigation{

--- a/frontend/src/css/parametres.css
+++ b/frontend/src/css/parametres.css
@@ -1,0 +1,64 @@
+/* 
+Copyright ou © ou Copr. Cécile Rolland, (21 janvier 2025) 
+
+aquarium[@]mailo[.]com
+
+Ce logiciel est un programme informatique servant à l'analyse des collectes
+traçologiques effectuées avec le logiciel DFIR-ORC. 
+
+Ce logiciel est régi par la licence CeCILL soumise au droit français et
+respectant les principes de diffusion des logiciels libres. Vous pouvez
+utiliser, modifier et/ou redistribuer ce programme sous les conditions
+de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA 
+sur le site "http://www.cecill.info".
+
+En contrepartie de l'accessibilité au code source et des droits de copie,
+de modification et de redistribution accordés par cette licence, il n'est
+offert aux utilisateurs qu'une garantie limitée.  Pour les mêmes raisons,
+seule une responsabilité restreinte pèse sur l'auteur du programme,  le
+titulaire des droits patrimoniaux et les concédants successifs.
+
+A cet égard  l'attention de l'utilisateur est attirée sur les risques
+associés au chargement,  à l'utilisation,  à la modification et/ou au
+développement et à la reproduction du logiciel par l'utilisateur étant 
+donné sa spécificité de logiciel libre, qui peut le rendre complexe à 
+manipuler et qui le réserve donc à des développeurs et des professionnels
+avertis possédant  des  connaissances  informatiques approfondies.  Les
+utilisateurs sont donc invités à charger  et  tester  l'adéquation  du
+logiciel à leurs besoins dans des conditions permettant d'assurer la
+sécurité de leurs systèmes et ou de leurs données et, plus généralement, 
+à l'utiliser et l'exploiter dans les mêmes conditions de sécurité. 
+
+Le fait que vous puissiez accéder à cet en-tête signifie que vous avez 
+pris connaissance de la licence CeCILL, et que vous en avez accepté les
+termes.
+*/
+
+.bouton_fermeture_parametres {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 40px;
+    height: 40px;
+    border: none;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+}
+
+.icone_fermeture_parametres {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+#titre_parametres {
+    align-self: flex-start;
+    text-align: left;
+    margin-left: 12px;
+}
+
+#zone_bouton_parametres {
+    align-self: flex-start;
+    margin-left: 10px;
+}

--- a/frontend/src/html/nouvelle_analyse.html
+++ b/frontend/src/html/nouvelle_analyse.html
@@ -54,6 +54,9 @@ termes.
     <h1>Nouvelle analyse ORC</h1>
     <h3 id="patientez">Import de l’ORC en cours... En attendant, nous vous conseillons de buller 🫧😏</h3>
     <div id="formulaire" class="cadre_clair">
+        <button class="bouton_fermeture_nouvelle_analyse" onclick="quitter_nouvelle_analyse()" aria-label="Fermer la creation d'analyse">
+            <img class="icone_fermeture_nouvelle_analyse" src="../assets/images/croix-fermer-noire.svg" alt="Fermer">
+        </button>
         <input type="radio" id="etape_1" name="case-navigation" checked>
         <input type="radio" id="etape_2" name="case-navigation" disabled>
         <input type="radio" id="etape_3" name="case-navigation" disabled>

--- a/frontend/src/html/parametres.html
+++ b/frontend/src/html/parametres.html
@@ -42,12 +42,75 @@ termes.
     <title>Parametres</title>
     <link rel="stylesheet" href="../templates/bibliotheque.css">
     <link rel="stylesheet" href="../templates/commun_sombre.css">
+    <style>
+        .bouton_fermeture_parametres {
+            position: absolute;
+            top: 16px;
+            right: 16px;
+            width: 40px;
+            height: 40px;
+            border: none;
+            background: transparent;
+            padding: 0;
+            cursor: pointer;
+        }
+
+        .icone_fermeture_parametres {
+            width: 100%;
+            height: 100%;
+            display: block;
+        }
+
+        #titre_parametres {
+            align-self: flex-start;
+            text-align: left;
+            margin-left: 12px;
+        }
+
+        #zone_bouton_parametres {
+            align-self: flex-start;
+            margin-left: 10px;
+        }
+
+        #toast_parametres {
+            position: fixed;
+            top: 16px;
+            right: 16px;
+            z-index: 1000;
+            display: none;
+            align-items: center;
+            gap: 12px;
+            max-width: 420px;
+            padding: 12px 14px;
+            border-radius: 8px;
+            background-color: #111;
+            color: #fff;
+            box-shadow: 0 10px 24px #0008;
+        }
+
+        #toast_parametres button {
+            border: none;
+            background: transparent;
+            color: #fff;
+            font-size: 18px;
+            line-height: 1;
+            cursor: pointer;
+            padding: 0;
+        }
+    </style>
     <script src="../js/outils/bubulles.js" async></script>
     <script src="../js/parametres.js" async></script>
     <script src="../templates/bibliotheque.js" async></script>
 </head>
 <body>
-    <h1>Paramètres</h1>
+    <div id="toast_parametres">
+        <span id="message_toast_parametres"></span>
+        <button onclick="fermer_toast_parametres()" aria-label="Fermer la notification">❌</button>
+    </div>
+    <button class="bouton_fermeture_parametres" onclick="fermer_parametres_sans_enregistrer()" aria-label="Fermer les paramètres">
+        <img class="icone_fermeture_parametres" src="../assets/images/croix-fermer-blanche.svg" alt="Fermer">
+    </button>
+    <h1 id="titre_parametres">Paramètres</h1>
     <div class="champ">
         <input type="checkbox" id="contrastes" onchange="changer_contrastes()">
         <label for="contrastes">Mode contrastes élevés</label>
@@ -60,8 +123,8 @@ termes.
         <input type="checkbox" id="non_aux_bubulles" onchange="enlever_bubulles()">
         <label for="non_aux_bubulles">Désactiver l'affichage des bulles 🥲</label>
     </div>
-    <div>
-    <button class="bouton_clair" onclick="quitter_parametres()">Enregistrer</button>
-</div>
+    <div id="zone_bouton_parametres">
+        <button class="bouton_clair" onclick="quitter_parametres()">Enregistrer</button>
+    </div>
 </body>
 </html>

--- a/frontend/src/html/parametres.html
+++ b/frontend/src/html/parametres.html
@@ -42,68 +42,13 @@ termes.
     <title>Parametres</title>
     <link rel="stylesheet" href="../templates/bibliotheque.css">
     <link rel="stylesheet" href="../templates/commun_sombre.css">
-    <style>
-        .bouton_fermeture_parametres {
-            position: absolute;
-            top: 16px;
-            right: 16px;
-            width: 40px;
-            height: 40px;
-            border: none;
-            background: transparent;
-            padding: 0;
-            cursor: pointer;
-        }
-
-        .icone_fermeture_parametres {
-            width: 100%;
-            height: 100%;
-            display: block;
-        }
-
-        #titre_parametres {
-            align-self: flex-start;
-            text-align: left;
-            margin-left: 12px;
-        }
-
-        #zone_bouton_parametres {
-            align-self: flex-start;
-            margin-left: 10px;
-        }
-
-        #toast_parametres {
-            position: fixed;
-            top: 16px;
-            right: 16px;
-            z-index: 1000;
-            display: none;
-            align-items: center;
-            gap: 12px;
-            max-width: 420px;
-            padding: 12px 14px;
-            border-radius: 8px;
-            background-color: #111;
-            color: #fff;
-            box-shadow: 0 10px 24px #0008;
-        }
-
-        #toast_parametres button {
-            border: none;
-            background: transparent;
-            color: #fff;
-            font-size: 18px;
-            line-height: 1;
-            cursor: pointer;
-            padding: 0;
-        }
-    </style>
+    <link rel="stylesheet" href="../css/parametres.css">
     <script src="../js/outils/bubulles.js" async></script>
     <script src="../js/parametres.js" async></script>
     <script src="../templates/bibliotheque.js" async></script>
 </head>
 <body>
-    <div id="toast_parametres">
+    <div id="toast_parametres" class="toast_notification toast_succes">
         <span id="message_toast_parametres"></span>
         <button onclick="fermer_toast_parametres()" aria-label="Fermer la notification">❌</button>
     </div>

--- a/frontend/src/js/nouvelle_analyse.js
+++ b/frontend/src/js/nouvelle_analyse.js
@@ -105,6 +105,10 @@ function afficher_bloc(a_afficher, id){
     }
 }
 
+function quitter_nouvelle_analyse(){
+    window.location.replace("../html/accueil.html");
+}
+
 function verifier_remplissage(section, prochaine_etape){
     let element = document.getElementById(section);
     if(section_remplie(element, true)){

--- a/frontend/src/js/parametres.js
+++ b/frontend/src/js/parametres.js
@@ -37,13 +37,15 @@ termes.
 let redirection_apres_toast = false;
 let timer_toast_parametres = null;
 
-function afficher_toast_parametres(message, rediriger){
+function afficher_toast_parametres(message, rediriger, type_toast = "succes"){
     redirection_apres_toast = rediriger;
     if(timer_toast_parametres != null){
         clearTimeout(timer_toast_parametres);
     }
+    let toast = document.getElementById("toast_parametres");
+    toast.className = "toast_notification " + (type_toast == "echec" ? "toast_echec" : "toast_succes");
     document.getElementById("message_toast_parametres").textContent = message;
-    document.getElementById("toast_parametres").style.display = "flex";
+    toast.style.display = "flex";
     timer_toast_parametres = setTimeout(fermer_toast_parametres, 5000);
 }
 
@@ -103,23 +105,23 @@ function enlever_bubulles(){
 function quitter_parametres(){
     const contrastes = document.getElementById("contrastes").checked;
     const dyslexie = document.getElementById("dyslexie").checked;
-    const nonAuxBubulles = document.getElementById("non_aux_bubulles").checked;
+    const non_aux_bubulles = document.getElementById("non_aux_bubulles").checked;
     const app = parent?.window?.go?.main?.App;
     if(app && typeof app.SauvegarderParametres === "function"){
-        Promise.resolve(app.SauvegarderParametres(contrastes, dyslexie, nonAuxBubulles))
+        Promise.resolve(app.SauvegarderParametres(contrastes, dyslexie, non_aux_bubulles))
             .then(resultat => {
                 if(resultat){
-                    afficher_toast_parametres("Les paramètres ont bien été enregistrés.", true);
+                    afficher_toast_parametres("Les paramètres ont bien été enregistrés.", true, "succes");
                 } else{
-                    afficher_toast_parametres("L'enregistrement des paramètres a échoué.", false);
+                    afficher_toast_parametres("L'enregistrement des paramètres a échoué.", false, "echec");
                 }
             })
             .catch(() => {
-                afficher_toast_parametres("L'enregistrement des paramètres a échoué.", false);
+                afficher_toast_parametres("L'enregistrement des paramètres a échoué.", false, "echec");
             });
         return;
     }
-    afficher_toast_parametres("L'enregistrement des paramètres a échoué.", false);
+    afficher_toast_parametres("L'enregistrement des paramètres a échoué.", false, "echec");
 }
 
 function contrastes_normaux(){

--- a/frontend/src/js/parametres.js
+++ b/frontend/src/js/parametres.js
@@ -34,6 +34,34 @@ pris connaissance de la licence CeCILL, et que vous en avez accepté les
 termes.
 */
 
+let redirection_apres_toast = false;
+let timer_toast_parametres = null;
+
+function afficher_toast_parametres(message, rediriger){
+    redirection_apres_toast = rediriger;
+    if(timer_toast_parametres != null){
+        clearTimeout(timer_toast_parametres);
+    }
+    document.getElementById("message_toast_parametres").textContent = message;
+    document.getElementById("toast_parametres").style.display = "flex";
+    timer_toast_parametres = setTimeout(fermer_toast_parametres, 5000);
+}
+
+function fermer_toast_parametres(){
+    if(timer_toast_parametres != null){
+        clearTimeout(timer_toast_parametres);
+        timer_toast_parametres = null;
+    }
+    document.getElementById("toast_parametres").style.display = "none";
+    if(redirection_apres_toast){
+        window.location.replace("accueil.html");
+    }
+}
+
+function fermer_parametres_sans_enregistrer(){
+    window.location.replace("accueil.html");
+}
+
 if(parent.contrastes){
     document.getElementById("contrastes").checked = true;
 }
@@ -73,7 +101,25 @@ function enlever_bubulles(){
 }
 
 function quitter_parametres(){
-    window.location.replace("accueil.html");
+    const contrastes = document.getElementById("contrastes").checked;
+    const dyslexie = document.getElementById("dyslexie").checked;
+    const nonAuxBubulles = document.getElementById("non_aux_bubulles").checked;
+    const app = parent?.window?.go?.main?.App;
+    if(app && typeof app.SauvegarderParametres === "function"){
+        Promise.resolve(app.SauvegarderParametres(contrastes, dyslexie, nonAuxBubulles))
+            .then(resultat => {
+                if(resultat){
+                    afficher_toast_parametres("Les paramètres ont bien été enregistrés.", true);
+                } else{
+                    afficher_toast_parametres("L'enregistrement des paramètres a échoué.", false);
+                }
+            })
+            .catch(() => {
+                afficher_toast_parametres("L'enregistrement des paramètres a échoué.", false);
+            });
+        return;
+    }
+    afficher_toast_parametres("L'enregistrement des paramètres a échoué.", false);
 }
 
 function contrastes_normaux(){

--- a/frontend/src/templates/bibliotheque.css
+++ b/frontend/src/templates/bibliotheque.css
@@ -357,6 +357,40 @@ input[type="checkbox"] {
     cursor: pointer;
 }
 
+.toast_notification{
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    z-index: 1000;
+    display: none;
+    align-items: center;
+    gap: 12px;
+    max-width: 420px;
+    padding: 12px 14px;
+    border-radius: 8px;
+    box-shadow: 0 10px 24px #0008;
+}
+
+.toast_notification button{
+    border: none;
+    background: transparent;
+    color: inherit;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0;
+}
+
+.toast_succes{
+    background-color: var(--bleu-1);
+    color: var(--or-6);
+}
+
+.toast_echec{
+    background-color: var(--rouge-cramoisi);
+    color: white;
+}
+
 
 .dossier_arborescence{
     margin-left: 20px;

--- a/frontend/src/templates/index.js
+++ b/frontend/src/templates/index.js
@@ -82,9 +82,33 @@ function creer_onglet(url, nomOnglet){
     change_onglet(url, bouton_onglet);
 }
 
-let contrastes = false;
-let dyslexie = false;
-let non_aux_bubulles = false;
+window.contrastes = false;
+window.dyslexie = false;
+window.non_aux_bubulles = false;
+
+function initialiser_parametres(tentatives_restantes = 20){
+    const app = window?.go?.main?.App;
+    if(!(app && typeof app.GetParametres === "function")){
+        if(tentatives_restantes > 0){
+            setTimeout(() => initialiser_parametres(tentatives_restantes - 1), 100);
+        }
+        return;
+    }
+    Promise.resolve(app.GetParametres()).then(parametres => {
+        if(parametres == null){
+            return;
+        }
+        window.contrastes = parametres.Contrastes === true;
+        window.dyslexie = parametres.Dyslexie === true;
+        window.non_aux_bubulles = parametres.NonAuxBubulles === true;
+        const iframe = document.getElementsByTagName("iframe")[0];
+        if(iframe && iframe.getAttribute("src")){
+            iframe.setAttribute("src", iframe.getAttribute("src"));
+        }
+    }).catch(() => {});
+}
+
+initialiser_parametres();
 
 function signaler_erreur(fichierErreur, detailsErreur){
     document.getElementById("texte_details_erreur").textContent = decodeURIComponent(detailsErreur).replaceAll("+"," ")

--- a/modules/aquabase/aquabase.go
+++ b/modules/aquabase/aquabase.go
@@ -841,6 +841,10 @@ func (adb Aquabase) EstResultatVide(requete string) (bool, error) {
 }
 
 func (adb *Aquabase) TailleRequeteSQL(requete string) int {
+	requete = strings.TrimSpace(requete)
+	for strings.HasSuffix(requete, ";") {
+		requete = strings.TrimSpace(strings.TrimSuffix(requete, ";"))
+	}
 	var requeteTotal string = fmt.Sprintf("SELECT COUNT(*) FROM (%s)", requete)
 	infosBDD, err := adb.Login()
 	if err != nil {

--- a/modules/arborescence/arborecsence.go
+++ b/modules/arborescence/arborecsence.go
@@ -119,7 +119,7 @@ func ExtraireArborescence(cheminProjet string, cheminModele string, idMachine st
 		ajouterFichierDansArbo(fichier, configMachine.Arborescence, &cache)
 	}
 	// Enregistrement de l’analyse
-	err = os.MkdirAll(filepath.Join(cheminProjet, config.DOSSIER_ANALYSE, DOSSIER_ARBO), os.ModeAppend)
+	err = os.MkdirAll(filepath.Join(cheminProjet, config.DOSSIER_ANALYSE, DOSSIER_ARBO), 0o755)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/modules/config/aqua_config.go
+++ b/modules/config/aqua_config.go
@@ -11,9 +11,9 @@ import (
 )
 
 type AquaConfig struct {
-	DebutAnalyse     time.Time                    `json:"debut_analyse"`
+	DebutAnalyse     time.Time                    `json:"debut_analyse" ts_type:"string"`
 	EntitesImpactees string                       `json:"entites_impactees"`
-	FinAnalyse       time.Time                    `json:"fin_analyse"`
+	FinAnalyse       time.Time                    `json:"fin_analyse" ts_type:"string"`
 	Analyste         string                       `json:"analyste"`
 	Machines         map[string]AquaConfigMachine `json:"machines"`
 	LiaisonsReseau   map[string]AquaConfigLiaison `json:"liaisons_reseau"`
@@ -24,7 +24,7 @@ type AquaConfig struct {
 }
 
 type AquaConfigEvenement struct {
-	Horodatage  time.Time `json:"horodatage"`
+	Horodatage  time.Time `json:"horodatage" ts_type:"string"`
 	Description string    `json:"description"`
 }
 

--- a/modules/detection/detection.go
+++ b/modules/detection/detection.go
@@ -57,7 +57,7 @@ type Regle struct {
 	Auteur      string    `json:"auteur"`
 	Description string    `json:"description"`
 	Criticite   int       `json:"criticite"`
-	Date        time.Time `json:"date"`
+	Date        time.Time `json:"date" ts_type:"string"`
 	SQL         string    `json:"sql"`
 	IsGlobal    bool
 }

--- a/modules/gestionprojet/gestionprojet.go
+++ b/modules/gestionprojet/gestionprojet.go
@@ -154,7 +154,7 @@ func ExtractArchive7z(archive string, destination string) error {
 	}
 	defer r.Close()
 
-	err = os.MkdirAll(destination, os.ModeAppend)
+	err = os.MkdirAll(destination, 0o755)
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func copieFichiersAAnalyser(cheminProjet string, configuration config.AquaConfig
 	for id_machine, machine := range configuration.Machines {
 		if machine.AAnalyser {
 			cheminDestination := filepath.Join(cheminProjet, config.DOSSIER_FICHIERS_A_ANALYSER, id_machine)
-			os.MkdirAll(cheminDestination, os.ModeAppend)
+			os.MkdirAll(cheminDestination, 0o755)
 			for _, cheminFichier := range machine.Fichiers {
 				cheminFichierDest := filepath.Join(cheminDestination, filepath.Base(cheminFichier))
 				err := ExtractArchive7z(cheminFichier, cheminFichierDest)

--- a/modules/params/CONFIG.md
+++ b/modules/params/CONFIG.md
@@ -1,0 +1,79 @@
+# Module `params` (fullstack)
+
+Ce module gère la persistance des préférences utilisateur de l’application :
+
+- `contrastes`
+- `dyslexie`
+- `non_aux_bubulles`
+
+Les préférences sont stockées dans `./config/params.xml`.
+
+## Format du fichier
+
+Le fichier attendu est :
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<parametres>
+  <contrastes>false</contrastes>
+  <dyslexie>false</dyslexie>
+  <non_aux_bubulles>true</non_aux_bubulles>
+</parametres>
+```
+
+## Backend (`Go`)
+
+Fichier : `modules/params/params.go`
+
+- `type ParametresXML`
+  - structure de mapping XML (`<parametres>...`).
+- `SauvegarderParametres(cheminBase, contrastes, dyslexie, nonAuxBubulles)`
+  - sérialise en XML,
+  - crée `./config` si nécessaire,
+  - écrit `./config/params.xml`.
+- `ChargerParametres(cheminBase)`
+  - lit et désérialise `./config/params.xml`,
+  - si le fichier n’existe pas, renvoie des valeurs par défaut (`false/false/false`) sans erreur bloquante.
+
+Intégration dans `app.go` :
+
+- `App.SauvegarderParametres(...)` : API Wails appelée par le frontend pour enregistrer.
+- `App.GetParametres()` : API Wails appelée au démarrage pour charger l’état courant.
+
+## Frontend (`JS/HTML`)
+
+### Chargement au démarrage
+
+Fichier : `frontend/src/templates/index.js`
+
+- `initialiser_parametres()` appelle `window.go.main.App.GetParametres()`.
+- Les variables globales de la fenêtre principale sont mises à jour :
+  - `contrastes`
+  - `dyslexie`
+  - `non_aux_bubulles`
+- L’iframe est rechargée pour appliquer immédiatement le style/comportement sur la page affichée.
+
+### Enregistrement depuis la page Paramètres
+
+Fichier : `frontend/src/js/parametres.js`
+
+- Le bouton **Enregistrer** appelle `quitter_parametres()`.
+- Cette fonction lit l’état des 3 cases puis appelle `window.go.main.App.SauvegarderParametres(...)`.
+- Une toast notification indique le résultat :
+  - succès : message + redirection vers l’accueil,
+  - échec : message d’erreur, sans redirection forcée.
+
+### Fermeture sans enregistrement
+
+La croix de fermeture (`parametres.html`) appelle `fermer_parametres_sans_enregistrer()` :
+
+- retour à l’accueil,
+- aucune écriture dans `params.xml`.
+
+## Résumé du flux
+
+1. Démarrage app : frontend appelle `GetParametres()`.
+2. Le backend lit `config/params.xml` (si présent) et renvoie l’état.
+3. Le frontend applique l’état global (contraste, police, bulles).
+4. L’utilisateur modifie les options dans l’écran Paramètres.
+5. Si **Enregistrer** : appel backend `SauvegarderParametres(...)` puis écriture XML.

--- a/modules/params/params.go
+++ b/modules/params/params.go
@@ -1,3 +1,39 @@
+/*
+Copyright ou © ou Copr. Cécile Rolland, (21 janvier 2025)
+
+aquarium[@]mailo[.]com
+
+Ce logiciel est un programme informatique servant à l'analyse des collectes
+traçologiques effectuées avec le logiciel DFIR-ORC.
+
+Ce logiciel est régi par la licence CeCILL soumise au droit français et
+respectant les principes de diffusion des logiciels libres. Vous pouvez
+utiliser, modifier et/ou redistribuer ce programme sous les conditions
+de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA
+sur le site "http://www.cecill.info".
+
+En contrepartie de l'accessibilité au code source et des droits de copie,
+de modification et de redistribution accordés par cette licence, il n'est
+offert aux utilisateurs qu'une garantie limitée.  Pour les mêmes raisons,
+seule une responsabilité restreinte pèse sur l'auteur du programme,  le
+titulaire des droits patrimoniaux et les concédants successifs.
+
+A cet égard  l'attention de l'utilisateur est attirée sur les risques
+associés au chargement,  à l'utilisation,  à la modification et/ou au
+développement et à la reproduction du logiciel par l'utilisateur étant
+donné sa spécificité de logiciel libre, qui peut le rendre complexe à
+manipuler et qui le réserve donc à des développeurs et des professionnels
+avertis possédant  des  connaissances  informatiques approfondies.  Les
+utilisateurs sont donc invités à charger  et  tester  l'adéquation  du
+logiciel à leurs besoins dans des conditions permettant d'assurer la
+sécurité de leurs systèmes et ou de leurs données et, plus généralement,
+à l'utiliser et l'exploiter dans les mêmes conditions de sécurité.
+
+Le fait que vous puissiez accéder à cet en-tête signifie que vous avez
+pris connaissance de la licence CeCILL, et que vous en avez accepté les
+termes.
+*/
+
 package params
 
 import (
@@ -8,8 +44,8 @@ import (
 )
 
 const (
-	DOSSIER_CONFIG = "config"
-	FICHIER_PARAMS = "params.xml"
+	dossierConfig = "config"
+	fichierParams = "params.xml"
 )
 
 type ParametresXML struct {
@@ -29,18 +65,18 @@ func SauvegarderParametres(cheminBase string, contrastes bool, dyslexie bool, no
 	if err != nil {
 		return err
 	}
-	cheminConfig := filepath.Join(cheminBase, DOSSIER_CONFIG)
+	cheminConfig := filepath.Join(cheminBase, dossierConfig)
 	if err = os.MkdirAll(cheminConfig, 0o755); err != nil {
 		return err
 	}
-	cheminFichier := filepath.Join(cheminConfig, FICHIER_PARAMS)
+	cheminFichier := filepath.Join(cheminConfig, fichierParams)
 	contenuFinal := append([]byte(xml.Header), contenuXML...)
 	return os.WriteFile(cheminFichier, contenuFinal, 0o644)
 }
 
 func ChargerParametres(cheminBase string) (ParametresXML, error) {
 	parametres := ParametresXML{}
-	cheminFichier := filepath.Join(cheminBase, DOSSIER_CONFIG, FICHIER_PARAMS)
+	cheminFichier := filepath.Join(cheminBase, dossierConfig, fichierParams)
 	contenu, err := os.ReadFile(cheminFichier)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/modules/params/params.go
+++ b/modules/params/params.go
@@ -1,0 +1,56 @@
+package params
+
+import (
+	"encoding/xml"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+const (
+	DOSSIER_CONFIG = "config"
+	FICHIER_PARAMS = "params.xml"
+)
+
+type ParametresXML struct {
+	XMLName        xml.Name `xml:"parametres" json:"-"`
+	Contrastes     bool     `xml:"contrastes"`
+	Dyslexie       bool     `xml:"dyslexie"`
+	NonAuxBubulles bool     `xml:"non_aux_bubulles"`
+}
+
+func SauvegarderParametres(cheminBase string, contrastes bool, dyslexie bool, nonAuxBubulles bool) error {
+	parametres := ParametresXML{
+		Contrastes:     contrastes,
+		Dyslexie:       dyslexie,
+		NonAuxBubulles: nonAuxBubulles,
+	}
+	contenuXML, err := xml.MarshalIndent(parametres, "", "  ")
+	if err != nil {
+		return err
+	}
+	cheminConfig := filepath.Join(cheminBase, DOSSIER_CONFIG)
+	if err = os.MkdirAll(cheminConfig, 0o755); err != nil {
+		return err
+	}
+	cheminFichier := filepath.Join(cheminConfig, FICHIER_PARAMS)
+	contenuFinal := append([]byte(xml.Header), contenuXML...)
+	return os.WriteFile(cheminFichier, contenuFinal, 0o644)
+}
+
+func ChargerParametres(cheminBase string) (ParametresXML, error) {
+	parametres := ParametresXML{}
+	cheminFichier := filepath.Join(cheminBase, DOSSIER_CONFIG, FICHIER_PARAMS)
+	contenu, err := os.ReadFile(cheminFichier)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return parametres, nil
+		}
+		return parametres, err
+	}
+	err = xml.Unmarshal(contenu, &parametres)
+	if err != nil {
+		return ParametresXML{}, err
+	}
+	return parametres, nil
+}

--- a/modules/params/params.go
+++ b/modules/params/params.go
@@ -1,5 +1,5 @@
 /*
-Copyright ou © ou Copr. Cécile Rolland, (21 janvier 2025)
+Copyright ou © ou Copr. Didier Hoizé, (20 avril 2026)
 
 aquarium[@]mailo[.]com
 

--- a/modules/utilitaires/utilitaires.go
+++ b/modules/utilitaires/utilitaires.go
@@ -1,15 +1,15 @@
-/* 
-Copyright ou © ou Copr. Didier Hoizé, (20 avril 2026) 
+/*
+Copyright ou © ou Copr. Didier Hoizé, (20 avril 2026)
 
 aquarium[@]mailo[.]com
 
 Ce logiciel est un programme informatique servant à l'analyse des collectes
-traçologiques effectuées avec le logiciel DFIR-ORC. 
+traçologiques effectuées avec le logiciel DFIR-ORC.
 
 Ce logiciel est régi par la licence CeCILL soumise au droit français et
 respectant les principes de diffusion des logiciels libres. Vous pouvez
 utiliser, modifier et/ou redistribuer ce programme sous les conditions
-de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA 
+de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA
 sur le site "http://www.cecill.info".
 
 En contrepartie de l'accessibilité au code source et des droits de copie,
@@ -20,45 +20,31 @@ titulaire des droits patrimoniaux et les concédants successifs.
 
 A cet égard  l'attention de l'utilisateur est attirée sur les risques
 associés au chargement,  à l'utilisation,  à la modification et/ou au
-développement et à la reproduction du logiciel par l'utilisateur étant 
-donné sa spécificité de logiciel libre, qui peut le rendre complexe à 
+développement et à la reproduction du logiciel par l'utilisateur étant
+donné sa spécificité de logiciel libre, qui peut le rendre complexe à
 manipuler et qui le réserve donc à des développeurs et des professionnels
 avertis possédant  des  connaissances  informatiques approfondies.  Les
 utilisateurs sont donc invités à charger  et  tester  l'adéquation  du
 logiciel à leurs besoins dans des conditions permettant d'assurer la
-sécurité de leurs systèmes et ou de leurs données et, plus généralement, 
-à l'utiliser et l'exploiter dans les mêmes conditions de sécurité. 
+sécurité de leurs systèmes et ou de leurs données et, plus généralement,
+à l'utiliser et l'exploiter dans les mêmes conditions de sécurité.
 
-Le fait que vous puissiez accéder à cet en-tête signifie que vous avez 
+Le fait que vous puissiez accéder à cet en-tête signifie que vous avez
 pris connaissance de la licence CeCILL, et que vous en avez accepté les
 termes.
 */
 
-.bouton_fermeture_parametres {
-    position: absolute;
-    top: 16px;
-    right: 16px;
-    width: 40px;
-    height: 40px;
-    border: none;
-    background: transparent;
-    padding: 0;
-    cursor: pointer;
-}
+package utilitaires
 
-.icone_fermeture_parametres {
-    width: 100%;
-    height: 100%;
-    display: block;
-}
+import (
+	"os"
+	"path/filepath"
+)
 
-#titre_parametres {
-    align-self: flex-start;
-    text-align: left;
-    margin-left: 12px;
-}
-
-#zone_bouton_parametres {
-    align-self: flex-start;
-    margin-left: 10px;
+func GetCheminBaseApplication() (string, error) {
+	emplacementExecutable, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(emplacementExecutable), nil
 }


### PR DESCRIPTION
feat: amélioration UI/UX des paramètres et persistance des préférences
- ajout d’icônes de fermeture (❌) sur les pages paramètres et nouvelle analyse
- gestion d’icônes adaptées au contraste (blanc/noir)
- sauvegarde des préférences (contrastes, dyslexie, bulles) dans ./config/params.xml
- refactorisation de la logique dans modules/params (sauvegarde + chargement)
- chargement automatique des préférences au démarrage
- remplacement des popups par des notifications toast (auto-fermeture + fermeture manuelle)
- correction du blocage de navigation dans quitter_parametres()
- modification du comportement : la croix quitte sans sauvegarder (bouton dédié)