### PR TITLE
Chore/frontend : création base de testing unitaires et E2E pour le front

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/bin
 
 # Go files
 go.sum
+go.mod
 
 # IDEs
 .idea
@@ -30,8 +31,12 @@ env
 
 frontend/src/assets/documents
 
+# Testing
+node_modules
+package-lock.json
+test-results
 
-go.mod
+# Perso Didier
 code.MD
 .DS_Store
 SUIVI-GIT.md

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Nous avons choisi d’utiliser les technologies Web en raison de leur relative s
 
 Nous avons choisi d’utiliser une base de données SQLite pour enregistrer les données extraites des collectes ORC. Il s’agit d’une bibliothèque en C permettant d’enregistrer des données manipulables grâce au langage SQL dans un unique fichier. Cela permet de tirer parti des avantages des bases de données SQL (facilité de requêtage, relative optimisation, organisation structurée,…) sans nécessiter le déploiement d’un serveur de bases de données. 
 
+## Testing
+
+### FRONT JS
+tests unitaires JS = vitest
+tests E2E = Playwright
+Mock Wails (simuler window.go)
+
+### BACK GO
+Utilisation de 'Testify' https://github.com/stretchr/testify
+
+
 # Architecture du logiciel
 
 ## Interface graphique

--- a/frontend/src/js/parametres.js
+++ b/frontend/src/js/parametres.js
@@ -1,5 +1,6 @@
 /*
 Copyright ou © ou Copr. Cécile Rolland, (21 janvier 2025) 
+Copyright ou © ou Copr. Didier Hoizé, (20 avril 2026)
 
 aquarium[@]mailo[.]com
 
@@ -94,6 +95,7 @@ function changer_dyslexie(){
 if(parent.non_aux_bubulles){
     document.getElementById("non_aux_bubulles").checked = true;
 }
+
 function enlever_bubulles(){
     if(document.getElementById("non_aux_bubulles").checked){
         parent.non_aux_bubulles = true;

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -9,6 +9,14 @@ https://v3alpha.wails.io/guides/e2e-testing/
 - `Playwright` : tests E2E pour valider les parcours complets utilisateur dans un navigateur réel.
 - `Mock Wails (window.go)` : permet de tester le frontend sans dépendre du backend Go en simulant les appels `window.go.main.App.*`.
 
+## Limites
+On ne teste PAS :
+> la vraie app desktop native
+> la WebView directement
+On teste via  :
+> la version web exposée par Wails
+C'est poiur cela qu'il faut 2 session de Terminal actives.
+
 ## Setup minimal
 
 1. Installer les dépendances JS de test dans le workspace frontend (Vitest + Playwright).
@@ -35,15 +43,12 @@ exemple pour macOs:
 - E2E (`Playwright`) : tester les scénarios critiques (navigation, sauvegarde paramètres, erreurs visibles).
 - Toujours contrôler les réponses Wails via mock (`succès`, `échec`, `exception`) pour couvrir les cas robustes.
 
-
 ## lancer les tests JS unitaires
 npx vitest run --config frontend/tests/vitest.config.mjs
 
 ## Lancer les tests Playwright (E2E)
-
 1. Démarrer l'application dans un terminal :
 `wails dev`
-
 2. Dans un second terminal, lancer les tests E2E :
 `npx playwright test --config frontend/tests/setup/playwright.config.js`
 

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -11,31 +11,36 @@ https://v3alpha.wails.io/guides/e2e-testing/
 
 ## Limites
 On ne teste PAS :
-> la vraie app desktop native
-> la WebView directement
+- la vraie app desktop native
+- la WebView directement
 On teste via  :
-> la version web exposée par Wails
+- la version web exposée par Wails
 C'est poiur cela qu'il faut 2 session de Terminal actives.
 
 ## Setup minimal
 
 1. Installer les dépendances JS de test dans le workspace frontend (Vitest + Playwright).
 > npm install -D vitest jsdom
-> npm install -D @playwright/test  > setup du framework https://v3alpha.wails.io/guides/e2e-testing/
-    added 3 packages, and audited 87 packages in 2s
-> npx playwright install  > Initialize les browsers Firefox + WebKit
+
+> npm install -D @playwright/test  
+ 
+2. Initialize les browsers Firefox + WebKit
+
+> npx playwright install  
+
 exemple pour macOs:
+    
     Downloading Firefox 148.0.2 (playwright firefox v1511) from https://cdn.playwright.dev/dbazure/download/playwright/builds/firefox/1511/firefox-mac-arm64.zip
     97.1 MiB [====================] 100% 0.0s
-    Firefox 148.0.2 (playwright firefox v1511) downloaded to /Users/.../Library/Caches/ms-playwright/firefox-1511
+    
     Downloading WebKit 26.4 (playwright webkit v2272) from https://cdn.playwright.dev/dbazure/download/playwright/builds/webkit/2272/webkit-mac-15-arm64.zip
     75.4 MiB [====================] 100% 0.0s
-    WebKit 26.4 (playwright webkit v2272) downloaded to /Users/.../Library/Caches/ms-playwright/webkit-2272
+    
 
 
-2. Configurer Vitest en environnement `jsdom`.
-3. Créer un mock partagé de `window.go` (ex: `test/mocks/wails.mock.js`).
-4. Charger ce mock dans les tests unitaires (setup Vitest) et E2E (injection Playwright avant chargement de page).
+3. Configurer Vitest en environnement `jsdom`.
+4. Créer un mock partagé de `window.go` (ex: `test/mocks/wails.mock.js`).
+5. Charger ce mock dans les tests unitaires (setup Vitest) et E2E (injection Playwright avant chargement de page).
 
 ## Règles d'usage
 

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -1,0 +1,57 @@
+# Tests frontend
+
+Aller voir : 
+https://v3alpha.wails.io/guides/e2e-testing/
+
+## Pourquoi cette stack
+
+- `Vitest` : tests unitaires JS rapides pour valider la logique (fonctions, transformations, états UI simples).
+- `Playwright` : tests E2E pour valider les parcours complets utilisateur dans un navigateur réel.
+- `Mock Wails (window.go)` : permet de tester le frontend sans dépendre du backend Go en simulant les appels `window.go.main.App.*`.
+
+## Setup minimal
+
+1. Installer les dépendances JS de test dans le workspace frontend (Vitest + Playwright).
+> npm install -D vitest jsdom
+> npm install -D @playwright/test  > setup du framework https://v3alpha.wails.io/guides/e2e-testing/
+    added 3 packages, and audited 87 packages in 2s
+> npx playwright install  > Initialize les browsers Firefox + WebKit
+exemple pour macOs:
+    Downloading Firefox 148.0.2 (playwright firefox v1511) from https://cdn.playwright.dev/dbazure/download/playwright/builds/firefox/1511/firefox-mac-arm64.zip
+    97.1 MiB [====================] 100% 0.0s
+    Firefox 148.0.2 (playwright firefox v1511) downloaded to /Users/.../Library/Caches/ms-playwright/firefox-1511
+    Downloading WebKit 26.4 (playwright webkit v2272) from https://cdn.playwright.dev/dbazure/download/playwright/builds/webkit/2272/webkit-mac-15-arm64.zip
+    75.4 MiB [====================] 100% 0.0s
+    WebKit 26.4 (playwright webkit v2272) downloaded to /Users/.../Library/Caches/ms-playwright/webkit-2272
+
+
+2. Configurer Vitest en environnement `jsdom`.
+3. Créer un mock partagé de `window.go` (ex: `test/mocks/wails.mock.js`).
+4. Charger ce mock dans les tests unitaires (setup Vitest) et E2E (injection Playwright avant chargement de page).
+
+## Règles d'usage
+
+- Unitaire (`Vitest`) : tester la logique isolée, sans backend réel.
+- E2E (`Playwright`) : tester les scénarios critiques (navigation, sauvegarde paramètres, erreurs visibles).
+- Toujours contrôler les réponses Wails via mock (`succès`, `échec`, `exception`) pour couvrir les cas robustes.
+
+
+## lancer les tests JS unitaires
+npx vitest run --config frontend/tests/vitest.config.mjs
+
+## Lancer les tests Playwright (E2E)
+
+1. Démarrer l'application dans un terminal :
+`wails dev`
+
+2. Dans un second terminal, lancer les tests E2E :
+`npx playwright test --config frontend/tests/setup/playwright.config.js`
+
+Commandes utiles :
+- Un seul fichier :
+`npx playwright test --config frontend/tests/setup/playwright.config.js frontend/tests/e2e/parametres.non_aux_bubulles.test.spec.js`
+- Mode UI :
+`npx playwright test --ui --config frontend/tests/setup/playwright.config.js`
+
+Erreur fréquente :
+- `ERR_CONNECTION_REFUSED` : vérifier que `wails dev` est bien lancé et que le port de `baseURL` dans `frontend/tests/setup/playwright.config.js` correspond au port réel.

--- a/frontend/tests/e2e/parametres.non_aux_bubulles.test.spec.js
+++ b/frontend/tests/e2e/parametres.non_aux_bubulles.test.spec.js
@@ -1,0 +1,133 @@
+/*
+Copyright ou © ou Copr. Didier Hoizé, (20 avril 2026)
+
+aquarium[@]mailo[.]com
+
+Ce logiciel est un programme informatique servant à l'analyse des collectes
+traçologiques effectuées avec le logiciel DFIR-ORC. 
+
+Ce logiciel est régi par la licence CeCILL soumise au droit français et
+respectant les principes de diffusion des logiciels libres. Vous pouvez
+utiliser, modifier et/ou redistribuer ce programme sous les conditions
+de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA 
+sur le site "http://www.cecill.info".
+
+En contrepartie de l'accessibilité au code source et des droits de copie,
+de modification et de redistribution accordés par cette licence, il n'est
+offert aux utilisateurs qu'une garantie limitée.  Pour les mêmes raisons,
+seule une responsabilité restreinte pèse sur l'auteur du programme,  le
+titulaire des droits patrimoniaux et les concédants successifs.
+
+A cet égard  l'attention de l'utilisateur est attirée sur les risques
+associés au chargement,  à l'utilisation,  à la modification et/ou au
+développement et à la reproduction du logiciel par l'utilisateur étant 
+donné sa spécificité de logiciel libre, qui peut le rendre complexe à 
+manipuler et qui le réserve donc à des développeurs et des professionnels
+avertis possédant  des  connaissances  informatiques approfondies.  Les
+utilisateurs sont donc invités à charger  et  tester  l'adéquation  du
+logiciel à leurs besoins dans des conditions permettant d'assurer la
+sécurité de leurs systèmes et ou de leurs données et, plus généralement, 
+à l'utiliser et l'exploiter dans les mêmes conditions de sécurité. 
+
+Le fait que vous puissiez accéder à cet en-tête signifie que vous avez 
+pris connaissance de la licence CeCILL, et que vous en avez accepté les
+termes.
+*/
+
+import { test, expect } from '@playwright/test';
+
+// Ouvre l'onglet Parametres depuis l'iframe de la page d'accueil
+// et retourne le frame locator prêt à être utilisé.
+async function ouvrirPageParametres(page) {
+  const accueilFrame = page.frameLocator('iframe[title="frame"]');
+  // Depuis la page principale, ouvre la page Parametres via le bouton dedie.
+  await accueilFrame.getByRole('button', { name: /Paramètres/i }).click();
+  await expect(accueilFrame.locator('h1#titre_parametres')).toBeVisible();
+  return accueilFrame;
+}
+
+// Simule la fin du parcours utilisateur apres sauvegarde:
+// enregistrement, fermeture de la notification, puis retour accueil.
+async function revenirAccueilDepuisParametres(frame) {
+  await frame.getByRole('button', { name: 'Enregistrer' }).click();
+  await expect(frame.locator('#toast_parametres')).toBeVisible();
+  // Sur cette page, la fermeture de la notification confirme le flux et
+  // declenche la redirection vers l'accueil quand l'enregistrement est un succes.
+  await frame.getByRole('button', { name: /Fermer la notification/i }).click();
+  await expect(frame.getByRole('heading', { name: /Bienvenue dans l’Aquarium/i })).toBeVisible();
+}
+
+// Normalise l'etat initial de la case "non_aux_bubulles" afin de rendre
+// le test deterministe, meme si un etat precedent a ete persiste.
+async function forcerEtatBubulles(page, checked) {
+  const frame = await ouvrirPageParametres(page);
+  const checkbox = frame.locator('#non_aux_bubulles');
+  if ((await checkbox.isChecked()) !== checked) {
+    if (checked) {
+      await checkbox.check();
+    } else {
+      await checkbox.uncheck();
+    }
+  }
+  await revenirAccueilDepuisParametres(frame);
+}
+
+// `test.describe` regroupe tout le parcours E2E lie aux parametres "bubulles".
+// Le `beforeEach` definit un environnement Wails mocke commun a chaque execution
+// du test pour garder des scenarios reproductibles et lisibles.
+test.describe('Parametres - non_aux_bubulles', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      // Etat partage entre pages/iframes pour simuler une persistance Wails.
+      const root = window.top;
+      root.__wailsMockState = root.__wailsMockState ?? {
+        Contrastes: false,
+        Dyslexie: false,
+        NonAuxBubulles: false,
+      };
+
+      window.go = {
+        main: {
+          App: {
+            async GetParametres() {
+              return { ...root.__wailsMockState };
+            },
+            async SauvegarderParametres(contrastes, dyslexie, nonAuxBubulles) {
+              root.__wailsMockState.Contrastes = contrastes === true;
+              root.__wailsMockState.Dyslexie = dyslexie === true;
+              root.__wailsMockState.NonAuxBubulles = nonAuxBubulles === true;
+              return true;
+            },
+          },
+        },
+      };
+    });
+
+    await page.goto('/');
+  });
+
+  test('Test 1.1 puis Test 1.2 - toggle et sauvegarde de "...bubulles"', async ({ page }) => {
+    // Base line robuste: l'etat peut deja etre persiste par un precedent run.
+    await forcerEtatBubulles(page, false);
+
+    await test.step('Test 1.1: cocher "enlever les bubulles", enregistrer, fermer la page Parametres', async () => {
+      const frame = await ouvrirPageParametres(page);
+      const checkbox = frame.locator('#non_aux_bubulles');
+
+      await expect(checkbox).not.toBeChecked();
+      await checkbox.check();
+
+      await revenirAccueilDepuisParametres(frame);
+    });
+
+    await test.step('Test 1.2: decocher "enlever les bubulles", enregistrer, fermer la page Parametres', async () => {
+      const frame = await ouvrirPageParametres(page);
+      const checkbox = frame.locator('#non_aux_bubulles');
+
+      await expect(checkbox).toBeChecked();
+      await checkbox.uncheck();
+
+      await revenirAccueilDepuisParametres(frame);
+    });
+  });
+});

--- a/frontend/tests/setup/playwright.config.js
+++ b/frontend/tests/setup/playwright.config.js
@@ -1,0 +1,44 @@
+/*
+Copyright ou © ou Copr. Didier Hoizé, (20 avril 2026)
+
+aquarium[@]mailo[.]com
+
+Ce logiciel est un programme informatique servant à l'analyse des collectes
+traçologiques effectuées avec le logiciel DFIR-ORC. 
+
+Ce logiciel est régi par la licence CeCILL soumise au droit français et
+respectant les principes de diffusion des logiciels libres. Vous pouvez
+utiliser, modifier et/ou redistribuer ce programme sous les conditions
+de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA 
+sur le site "http://www.cecill.info".
+
+En contrepartie de l'accessibilité au code source et des droits de copie,
+de modification et de redistribution accordés par cette licence, il n'est
+offert aux utilisateurs qu'une garantie limitée.  Pour les mêmes raisons,
+seule une responsabilité restreinte pèse sur l'auteur du programme,  le
+titulaire des droits patrimoniaux et les concédants successifs.
+
+A cet égard  l'attention de l'utilisateur est attirée sur les risques
+associés au chargement,  à l'utilisation,  à la modification et/ou au
+développement et à la reproduction du logiciel par l'utilisateur étant 
+donné sa spécificité de logiciel libre, qui peut le rendre complexe à 
+manipuler et qui le réserve donc à des développeurs et des professionnels
+avertis possédant  des  connaissances  informatiques approfondies.  Les
+utilisateurs sont donc invités à charger  et  tester  l'adéquation  du
+logiciel à leurs besoins dans des conditions permettant d'assurer la
+sécurité de leurs systèmes et ou de leurs données et, plus généralement, 
+à l'utiliser et l'exploiter dans les mêmes conditions de sécurité. 
+
+Le fait que vous puissiez accéder à cet en-tête signifie que vous avez 
+pris connaissance de la licence CeCILL, et que vous en avez accepté les
+termes.
+*/
+
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: '../e2e',
+  use: {
+    baseURL: 'http://localhost:34115', // Wails dev server
+  },
+})

--- a/frontend/tests/setup/vitest.setup.js
+++ b/frontend/tests/setup/vitest.setup.js
@@ -1,0 +1,57 @@
+/*
+Copyright ou © ou Copr. Didier Hoizé, (20 avril 2026)
+
+aquarium[@]mailo[.]com
+
+Ce logiciel est un programme informatique servant à l'analyse des collectes
+traçologiques effectuées avec le logiciel DFIR-ORC. 
+
+Ce logiciel est régi par la licence CeCILL soumise au droit français et
+respectant les principes de diffusion des logiciels libres. Vous pouvez
+utiliser, modifier et/ou redistribuer ce programme sous les conditions
+de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA 
+sur le site "http://www.cecill.info".
+
+En contrepartie de l'accessibilité au code source et des droits de copie,
+de modification et de redistribution accordés par cette licence, il n'est
+offert aux utilisateurs qu'une garantie limitée.  Pour les mêmes raisons,
+seule une responsabilité restreinte pèse sur l'auteur du programme,  le
+titulaire des droits patrimoniaux et les concédants successifs.
+
+A cet égard  l'attention de l'utilisateur est attirée sur les risques
+associés au chargement,  à l'utilisation,  à la modification et/ou au
+développement et à la reproduction du logiciel par l'utilisateur étant 
+donné sa spécificité de logiciel libre, qui peut le rendre complexe à 
+manipuler et qui le réserve donc à des développeurs et des professionnels
+avertis possédant  des  connaissances  informatiques approfondies.  Les
+utilisateurs sont donc invités à charger  et  tester  l'adéquation  du
+logiciel à leurs besoins dans des conditions permettant d'assurer la
+sécurité de leurs systèmes et ou de leurs données et, plus généralement, 
+à l'utiliser et l'exploiter dans les mêmes conditions de sécurité. 
+
+Le fait que vous puissiez accéder à cet en-tête signifie que vous avez 
+pris connaissance de la licence CeCILL, et que vous en avez accepté les
+termes.
+*/
+
+import { vi } from 'vitest';
+
+if (!global.parent) {
+  global.parent = {};
+}
+
+if (!global.parent.window) {
+  global.parent.window = {};
+}
+
+if (!global.parent.window.go) {
+  global.parent.window.go = { main: { App: {} } };
+}
+
+if (!global.contrastes_eleves) {
+  global.contrastes_eleves = vi.fn();
+}
+
+if (!global.police_dyslexie) {
+  global.police_dyslexie = vi.fn();
+}

--- a/frontend/tests/unit/parametres.enlever_bubulles.test.js
+++ b/frontend/tests/unit/parametres.enlever_bubulles.test.js
@@ -1,0 +1,94 @@
+/*
+Copyright ou © ou Copr. Didier Hoizé, (20 avril 2026)
+
+aquarium[@]mailo[.]com
+
+Ce logiciel est un programme informatique servant à l'analyse des collectes
+traçologiques effectuées avec le logiciel DFIR-ORC. 
+
+Ce logiciel est régi par la licence CeCILL soumise au droit français et
+respectant les principes de diffusion des logiciels libres. Vous pouvez
+utiliser, modifier et/ou redistribuer ce programme sous les conditions
+de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA 
+sur le site "http://www.cecill.info".
+
+En contrepartie de l'accessibilité au code source et des droits de copie,
+de modification et de redistribution accordés par cette licence, il n'est
+offert aux utilisateurs qu'une garantie limitée.  Pour les mêmes raisons,
+seule une responsabilité restreinte pèse sur l'auteur du programme,  le
+titulaire des droits patrimoniaux et les concédants successifs.
+
+A cet égard  l'attention de l'utilisateur est attirée sur les risques
+associés au chargement,  à l'utilisation,  à la modification et/ou au
+développement et à la reproduction du logiciel par l'utilisateur étant 
+donné sa spécificité de logiciel libre, qui peut le rendre complexe à 
+manipuler et qui le réserve donc à des développeurs et des professionnels
+avertis possédant  des  connaissances  informatiques approfondies.  Les
+utilisateurs sont donc invités à charger  et  tester  l'adéquation  du
+logiciel à leurs besoins dans des conditions permettant d'assurer la
+sécurité de leurs systèmes et ou de leurs données et, plus généralement, 
+à l'utiliser et l'exploiter dans les mêmes conditions de sécurité. 
+
+Le fait que vous puissiez accéder à cet en-tête signifie que vous avez 
+pris connaissance de la licence CeCILL, et que vous en avez accepté les
+termes.
+*/
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Ce test charge parametres.js dans jsdom et verifie que l'etat de la case
+// `#non_aux_bubulles` est bien synchronise vers `parent.non_aux_bubulles`.
+const scriptPath = path.resolve(process.cwd(), 'frontend/src/js/parametres.js');
+const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+
+function chargerScriptParametres() {
+  vi.stubGlobal('contrastes_eleves', vi.fn());
+  vi.stubGlobal('police_dyslexie', vi.fn());
+  window.eval(scriptContent);
+}
+
+describe('parametres.js - enlever_bubulles', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    document.body.innerHTML = `
+      <div id="toast_parametres"></div>
+      <div id="message_toast_parametres"></div>
+      <input id="contrastes" type="checkbox" />
+      <input id="dyslexie" type="checkbox" />
+      <input id="non_aux_bubulles" type="checkbox" />
+    `;
+
+    global.parent = {
+      contrastes: false,
+      dyslexie: false,
+      non_aux_bubulles: false,
+      window: {
+        go: { main: { App: {} } },
+      },
+    };
+
+    chargerScriptParametres();
+  });
+
+  it('synchronise parent.non_aux_bubulles a true quand la checkbox est cochee', () => {
+    const checkbox = document.getElementById('non_aux_bubulles');
+    checkbox.checked = true;
+
+    enlever_bubulles();
+
+    expect(parent.non_aux_bubulles).toBe(true);
+  });
+
+  it('synchronise parent.non_aux_bubulles a false quand la checkbox est decochee', () => {
+    const checkbox = document.getElementById('non_aux_bubulles');
+    checkbox.checked = false;
+    parent.non_aux_bubulles = true;
+
+    enlever_bubulles();
+
+    expect(parent.non_aux_bubulles).toBe(false);
+  });
+});

--- a/frontend/tests/unit/parametres.preferences.test.js
+++ b/frontend/tests/unit/parametres.preferences.test.js
@@ -1,0 +1,124 @@
+/*
+Copyright ou © ou Copr. Didier Hoizé, (20 avril 2026)
+
+aquarium[@]mailo[.]com
+
+Ce logiciel est un programme informatique servant à l'analyse des collectes
+traçologiques effectuées avec le logiciel DFIR-ORC. 
+
+Ce logiciel est régi par la licence CeCILL soumise au droit français et
+respectant les principes de diffusion des logiciels libres. Vous pouvez
+utiliser, modifier et/ou redistribuer ce programme sous les conditions
+de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA 
+sur le site "http://www.cecill.info".
+
+En contrepartie de l'accessibilité au code source et des droits de copie,
+de modification et de redistribution accordés par cette licence, il n'est
+offert aux utilisateurs qu'une garantie limitée.  Pour les mêmes raisons,
+seule une responsabilité restreinte pèse sur l'auteur du programme,  le
+titulaire des droits patrimoniaux et les concédants successifs.
+
+A cet égard  l'attention de l'utilisateur est attirée sur les risques
+associés au chargement,  à l'utilisation,  à la modification et/ou au
+développement et à la reproduction du logiciel par l'utilisateur étant 
+donné sa spécificité de logiciel libre, qui peut le rendre complexe à 
+manipuler et qui le réserve donc à des développeurs et des professionnels
+avertis possédant  des  connaissances  informatiques approfondies.  Les
+utilisateurs sont donc invités à charger  et  tester  l'adéquation  du
+logiciel à leurs besoins dans des conditions permettant d'assurer la
+sécurité de leurs systèmes et ou de leurs données et, plus généralement, 
+à l'utiliser et l'exploiter dans les mêmes conditions de sécurité. 
+
+Le fait que vous puissiez accéder à cet en-tête signifie que vous avez 
+pris connaissance de la licence CeCILL, et que vous en avez accepté les
+termes.
+*/
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const scriptPath = path.resolve(process.cwd(), 'frontend/src/js/parametres.js');
+const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+
+function chargerScriptParametres() {
+  vi.stubGlobal('contrastes_eleves', vi.fn());
+  vi.stubGlobal('police_dyslexie', vi.fn());
+  window.eval(scriptContent);
+}
+
+describe('parametres.js - preferences UI', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    document.body.innerHTML = `
+      <div id="toast_parametres"></div>
+      <div id="message_toast_parametres"></div>
+      <input id="contrastes" type="checkbox" />
+      <input id="dyslexie" type="checkbox" />
+      <input id="non_aux_bubulles" type="checkbox" />
+    `;
+
+    global.parent = {
+      contrastes: false,
+      dyslexie: false,
+      non_aux_bubulles: false,
+      window: {
+        go: { main: { App: {} } },
+      },
+    };
+
+    chargerScriptParametres();
+  });
+
+  it('changer_contrastes: met parent.contrastes a true et appelle contrastes_eleves', () => {
+    const checkbox = document.getElementById('contrastes');
+    checkbox.checked = true;
+
+    const contrastesNormauxSpy = vi.fn();
+    contrastes_normaux = contrastesNormauxSpy;
+
+    changer_contrastes();
+
+    expect(parent.contrastes).toBe(true);
+    expect(contrastes_eleves).toHaveBeenCalledTimes(1);
+    expect(contrastesNormauxSpy).not.toHaveBeenCalled();
+  });
+
+  it('changer_contrastes: met parent.contrastes a false et appelle contrastes_normaux', () => {
+    const checkbox = document.getElementById('contrastes');
+    checkbox.checked = false;
+    parent.contrastes = true;
+
+    const contrastesNormauxSpy = vi.fn();
+    contrastes_normaux = contrastesNormauxSpy;
+
+    changer_contrastes();
+
+    expect(parent.contrastes).toBe(false);
+    expect(contrastesNormauxSpy).toHaveBeenCalledTimes(1);
+    expect(contrastes_eleves).not.toHaveBeenCalled();
+  });
+
+  it('changer_dyslexie: met parent.dyslexie a true et appelle police_dyslexie', () => {
+    const checkbox = document.getElementById('dyslexie');
+    checkbox.checked = true;
+
+    changer_dyslexie();
+
+    expect(parent.dyslexie).toBe(true);
+    expect(police_dyslexie).toHaveBeenCalledTimes(1);
+  });
+
+  it('changer_dyslexie: met parent.dyslexie a false et applique la police fallback', () => {
+    const checkbox = document.getElementById('dyslexie');
+    checkbox.checked = false;
+    parent.dyslexie = true;
+
+    changer_dyslexie();
+
+    expect(parent.dyslexie).toBe(false);
+    expect(document.body.style.fontFamily).toContain('Comic Sans Ms');
+    expect(police_dyslexie).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/unit/parametres.quitter_parametres.test.js
+++ b/frontend/tests/unit/parametres.quitter_parametres.test.js
@@ -1,0 +1,136 @@
+/*
+Copyright ou © ou Copr. Didier Hoizé, (20 avril 2026)
+
+aquarium[@]mailo[.]com
+
+Ce logiciel est un programme informatique servant à l'analyse des collectes
+traçologiques effectuées avec le logiciel DFIR-ORC. 
+
+Ce logiciel est régi par la licence CeCILL soumise au droit français et
+respectant les principes de diffusion des logiciels libres. Vous pouvez
+utiliser, modifier et/ou redistribuer ce programme sous les conditions
+de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA 
+sur le site "http://www.cecill.info".
+
+En contrepartie de l'accessibilité au code source et des droits de copie,
+de modification et de redistribution accordés par cette licence, il n'est
+offert aux utilisateurs qu'une garantie limitée.  Pour les mêmes raisons,
+seule une responsabilité restreinte pèse sur l'auteur du programme,  le
+titulaire des droits patrimoniaux et les concédants successifs.
+
+A cet égard  l'attention de l'utilisateur est attirée sur les risques
+associés au chargement,  à l'utilisation,  à la modification et/ou au
+développement et à la reproduction du logiciel par l'utilisateur étant 
+donné sa spécificité de logiciel libre, qui peut le rendre complexe à 
+manipuler et qui le réserve donc à des développeurs et des professionnels
+avertis possédant  des  connaissances  informatiques approfondies.  Les
+utilisateurs sont donc invités à charger  et  tester  l'adéquation  du
+logiciel à leurs besoins dans des conditions permettant d'assurer la
+sécurité de leurs systèmes et ou de leurs données et, plus généralement, 
+à l'utiliser et l'exploiter dans les mêmes conditions de sécurité. 
+
+Le fait que vous puissiez accéder à cet en-tête signifie que vous avez 
+pris connaissance de la licence CeCILL, et que vous en avez accepté les
+termes.
+*/
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const scriptPath = path.resolve(process.cwd(), 'frontend/src/js/parametres.js');
+const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+// Laisse le temps aux .then/.catch de se resoudre avant les assertions.
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function chargerScriptParametres() {
+  // Mock des fonctions globales utilisees par parametres.js.
+  vi.stubGlobal('contrastes_eleves', vi.fn());
+  vi.stubGlobal('police_dyslexie', vi.fn());
+  // Charge le script tel qu'il tourne dans le navigateur.
+  window.eval(scriptContent);
+}
+
+describe('parametres.js - quitter_parametres', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    document.body.innerHTML = `
+      <div id="toast_parametres"></div>
+      <div id="message_toast_parametres"></div>
+      <input id="contrastes" type="checkbox" />
+      <input id="dyslexie" type="checkbox" />
+      <input id="non_aux_bubulles" type="checkbox" />
+    `;
+
+    global.parent = {
+      contrastes: false,
+      dyslexie: false,
+      non_aux_bubulles: false,
+      window: {
+        go: {
+          main: {
+            App: {
+              SauvegarderParametres: vi.fn(),
+            },
+          },
+        },
+      },
+    };
+
+    chargerScriptParametres();
+  });
+
+  it('envoie les 3 bons booleens a SauvegarderParametres', () => {
+    // Contrat principal frontend -> backend: ordre et valeurs des 3 flags.
+    document.getElementById('contrastes').checked = true;
+    document.getElementById('dyslexie').checked = false;
+    document.getElementById('non_aux_bubulles').checked = true;
+
+    parent.window.go.main.App.SauvegarderParametres.mockResolvedValue(true);
+
+    quitter_parametres();
+
+    expect(parent.window.go.main.App.SauvegarderParametres).toHaveBeenCalledTimes(1);
+    expect(parent.window.go.main.App.SauvegarderParametres).toHaveBeenCalledWith(true, false, true);
+  });
+
+  it('gere le retour backend true', async () => {
+    // Si sauvegarde OK, on attend un feedback succes avec redirection.
+    const toastSpy = vi.fn();
+    afficher_toast_parametres = toastSpy;
+
+    parent.window.go.main.App.SauvegarderParametres.mockResolvedValue(true);
+
+    quitter_parametres();
+    await flushPromises();
+
+    expect(toastSpy).toHaveBeenCalledWith('Les paramètres ont bien été enregistrés.', true, 'succes');
+  });
+
+  it('gere le retour backend false', async () => {
+    // Si backend renvoie false, le flux doit rester en echec non bloquant.
+    const toastSpy = vi.fn();
+    afficher_toast_parametres = toastSpy;
+
+    parent.window.go.main.App.SauvegarderParametres.mockResolvedValue(false);
+
+    quitter_parametres();
+    await flushPromises();
+
+    expect(toastSpy).toHaveBeenCalledWith("L'enregistrement des paramètres a échoué.", false, 'echec');
+  });
+
+  it('gere une exception backend', async () => {
+    // En cas d'exception, le comportement attendu est identique a un echec.
+    const toastSpy = vi.fn();
+    afficher_toast_parametres = toastSpy;
+
+    parent.window.go.main.App.SauvegarderParametres.mockRejectedValue(new Error('backend indisponible'));
+
+    quitter_parametres();
+    await flushPromises();
+
+    expect(toastSpy).toHaveBeenCalledWith("L'enregistrement des paramètres a échoué.", false, 'echec');
+  });
+});

--- a/frontend/tests/vitest.config.mjs
+++ b/frontend/tests/vitest.config.mjs
@@ -1,0 +1,48 @@
+/*
+Copyright ou © ou Copr. Didier Hoizé, (20 avril 2026)
+
+aquarium[@]mailo[.]com
+
+Ce logiciel est un programme informatique servant à l'analyse des collectes
+traçologiques effectuées avec le logiciel DFIR-ORC.
+
+Ce logiciel est régi par la licence CeCILL soumise au droit français et
+respectant les principes de diffusion des logiciels libres. Vous pouvez
+utiliser, modifier et/ou redistribuer ce programme sous les conditions
+de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA
+sur le site "http://www.cecill.info".
+
+En contrepartie de l'accessibilité au code source et des droits de copie,
+de modification et de redistribution accordés par cette licence, il n'est
+offert aux utilisateurs qu'une garantie limitée.  Pour les mêmes raisons,
+seule une responsabilité restreinte pèse sur l'auteur du programme,  le
+titulaire des droits patrimoniaux et les concédants successifs.
+
+A cet égard  l'attention de l'utilisateur est attirée sur les risques
+associés au chargement,  à l'utilisation,  à la modification et/ou au
+développement et à la reproduction du logiciel par l'utilisateur étant
+donné sa spécificité de logiciel libre, qui peut le rendre complexe à
+manipuler et qui le réserve donc à des développeurs et des professionnels
+avertis possédant  des  connaissances  informatiques approfondies.  Les
+utilisateurs sont donc invités à charger  et  tester  l'adéquation  du
+logiciel à leurs besoins dans des conditions permettant d'assurer la
+sécurité de leurs systèmes et ou de leurs données et, plus généralement,
+à l'utiliser et l'exploiter dans les mêmes conditions de sécurité.
+
+Le fait que vous puissiez accéder à cet en-tête signifie que vous avez
+pris connaissance de la licence CeCILL, et que vous en avez accepté les
+termes.
+*/
+
+
+import { defineConfig } from 'vitest/config';
+
+// Configuration centralisee des tests frontend: jsdom pour le DOM, setup global
+// pour les mocks Wails, et execution limitee aux tests unitaires du dossier frontend/tests/unit.
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['frontend/tests/unit/**/*.test.js'],
+    setupFiles: ['frontend/tests/setup/vitest.setup.js'],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "jsdom": "^29.1.0",
+    "vitest": "^4.1.5"
+  }
+}


### PR DESCRIPTION
- Mise en place d'une base de tests frontend et utilisation de Vitest
- Ajout d'un jeux de tests unitaires sur "/parametres"
- Mise en place E2E Playwright et création d'un scénario de tests
- Ajout Readme.md dédié